### PR TITLE
Add GitHub action for shellcheck and make it compatible with Bash-5 and for MacOS, too

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,43 @@
+name: Shellcheck Lint
+
+on:
+  push:
+    branches:
+      # Run workflow on every push
+      - '**'        # matches every branch
+
+  pull_request:
+    branches:
+      # Run workflow on every push
+      - '**'        # matches every branch
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Shellcheck Lint
+
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      # Required to access files of this repository
+      - uses: actions/checkout@v2
+
+      # Download Shellcheck and add it to the workflow path
+      - name: Download Shellcheck
+        run: |
+          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv
+          chmod +x shellcheck-stable/shellcheck
+      # Verify that Shellcheck can be executed
+      - name: Check Shellcheck Version
+        run: |
+          shellcheck-stable/shellcheck --version
+
+      # Run Shellcheck on repository
+      - name: Run Shellcheck
+        run: |
+          set +e
+          shellcheck-stable/shellcheck --color=always --severity=warning --exclude=SC1090,SC1091 syncthing-quick-status.sh
+

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,43 +1,16 @@
-name: Shellcheck Lint
+name: Shellcheck
 
 on:
   push:
-    branches:
-      # Run workflow on every push
-      - '**'        # matches every branch
-
+    branches: [ main ]
   pull_request:
-    branches:
-      # Run workflow on every push
-      - '**'        # matches every branch
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    branches: [ main ]
 
 jobs:
-  build:
-    name: Shellcheck Lint
-
-    # This job runs on Linux
+  shellcheck:
+    name: Shellcheck
     runs-on: ubuntu-latest
-
     steps:
-      # Required to access files of this repository
-      - uses: actions/checkout@v2
-
-      # Download Shellcheck and add it to the workflow path
-      - name: Download Shellcheck
-        run: |
-          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz" | tar -xJv
-          chmod +x shellcheck-stable/shellcheck
-      # Verify that Shellcheck can be executed
-      - name: Check Shellcheck Version
-        run: |
-          shellcheck-stable/shellcheck --version
-
-      # Run Shellcheck on repository
-      - name: Run Shellcheck
-        run: |
-          set +e
-          shellcheck-stable/shellcheck --color=always --severity=warning --exclude=SC1090,SC1091 syncthing-quick-status.sh
-
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ An elegant(?), fast(?) and colorful(!) solution to have the complete(?) `syncthi
 
 ## Dependencies
 
-* bash 4
+* bash 4 or 5
 * `curl`
 * `jq`
+* works on Linux as well as on MacOS
 
 ## Env variables
 
 * `SYNCTHING_API_KEY`.
-* `SYNCTHING_CONFIG_FILE`, the place where it'll look for the api key if not given in the variable above. Defaults to `$HOME/.config/syncthing/config.xml`.
+* `SYNCTHING_CONFIG_FILE`, the place where it'll look for the api key if not given in the variable above. Defaults to `$HOME/.config/syncthing/config.xml` on Linux and `$HOME/Library/Application Support/Syncthing/config.xml` on MacOS.
 * `SYNCTHING_ADDRESS`, defaults to `localhost:8384`.
 
 ## Arguments
 
-* `-v`: verbose, show devices/folder ids and a selection of latest log messages.
+* `-v`: verbose, show devices/folder ids and a selection of latest log messages (which is specially helpful for more details about "out of sync" folders).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An elegant(?), fast(?) and colorful(!) solution to have the complete(?) `syncthi
 
 ## Dependencies
 
-* bash 4 or 5
+* bash 4+
 * `curl`
 * `jq`
 * works on Linux as well as on MacOS

--- a/syncthing-quick-status.sh
+++ b/syncthing-quick-status.sh
@@ -14,17 +14,14 @@ done
 	exit 1
 
 if [[ -z $SYNCTHING_API_KEY ]]; then
-         # MacOS stores config.xml in a different path:
-         case "$(uname -o)" in
-           *Linux)
-             : "${SYNCTHING_CONFIG_FILE:="$HOME/.config/syncthing/config.xml"}" ;;
-           Darwin)
-             : "${SYNCTHING_CONFIG_FILE:="$HOME/Library/Application Support/Syncthing/config.xml"}" ;;
-            *)
-              echo "Only *Linux and Darwin operating systems are supported - if you think this is an error, please open an issue: https://github.com/serl/syncthing-quick-status/issues/new"; exit ;;
-         esac
-         apikey_regex="^\s+<apikey>([^<]+)</apikey>$"
-         apikey_line="$(grep -E "$apikey_regex" "$SYNCTHING_CONFIG_FILE")"
+	SYNCTHING_DEFAULT_CONFIG_FILE="$HOME/.config/syncthing/config.xml"
+	if [[ $(uname) = Darwin ]]; then
+		# config.xml is stored in a different path in MacOS:
+		SYNCTHING_DEFAULT_CONFIG_FILE="$HOME/Library/Application Support/Syncthing/config.xml"
+	fi
+	: "${SYNCTHING_CONFIG_FILE:="$SYNCTHING_DEFAULT_CONFIG_FILE"}"
+	apikey_regex='^\s+<apikey>([^<]+)</apikey>$'
+	apikey_line="$(grep -E "$apikey_regex" "$SYNCTHING_CONFIG_FILE")"
 	[[ $apikey_line =~ $apikey_regex ]] &&
 		SYNCTHING_API_KEY=${BASH_REMATCH[1]}
 fi

--- a/syncthing-quick-status.sh
+++ b/syncthing-quick-status.sh
@@ -14,15 +14,24 @@ done
 	exit 1
 
 if [[ -z $SYNCTHING_API_KEY ]]; then
-	: "${SYNCTHING_CONFIG_FILE:="$HOME/.config/syncthing/config.xml"}"
-       # MacOS stores config.xml in a different path:
-       uname -o | grep -q Darwin && SYNCTHING_CONFIG_FILE="$HOME/Library/Application Support/Syncthing/config.xml"
-       apikey_regex="^\s+<apikey>([^<]+)</apikey>$"
-       apikey_line="$(grep -E "$apikey_regex" "$SYNCTHING_CONFIG_FILE")"
+         # MacOS stores config.xml in a different path:
+         case "$(uname -o)" in
+           *Linux)
+             : "${SYNCTHING_CONFIG_FILE:="$HOME/.config/syncthing/config.xml"}" ;;
+           Darwin)
+             : "${SYNCTHING_CONFIG_FILE:="$HOME/Library/Application Support/Syncthing/config.xml"}" ;;
+            *)
+              echo "Only *Linux and Darwin operating systems are supported - if you think this is an error, please open an issue: https://github.com/serl/syncthing-quick-status/issues/new"; exit ;;
+         esac
+         apikey_regex="^\s+<apikey>([^<]+)</apikey>$"
+         apikey_line="$(grep -E "$apikey_regex" "$SYNCTHING_CONFIG_FILE")"
 	[[ $apikey_line =~ $apikey_regex ]] &&
 		SYNCTHING_API_KEY=${BASH_REMATCH[1]}
 fi
 
+if [[ -z $SYNCTHING_API_KEY ]]; then
+         SYNCTHING_API_KEY=$(echo "$apikey_line" | cut -d ">" -f2|cut -d"<" -f1 2>/dev/null)
+fi
 if [[ -z $SYNCTHING_API_KEY ]]; then
 	echo "No API key in env. Set one of the variables SYNCTHING_API_KEY or SYNCTHING_CONFIG_FILE and try again..."
 	exit 1

--- a/syncthing-quick-status.sh
+++ b/syncthing-quick-status.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ((BASH_VERSINFO[0] < 4)); then
 	echo "This script needs at least bash 4."
@@ -15,8 +15,10 @@ done
 
 if [[ -z $SYNCTHING_API_KEY ]]; then
 	: "${SYNCTHING_CONFIG_FILE:="$HOME/.config/syncthing/config.xml"}"
-	apikey_regex='^\s+<apikey>([^<]+)</apikey>$'
-	apikey_line="$(grep -E "$apikey_regex" "$SYNCTHING_CONFIG_FILE")"
+       # MacOS stores config.xml in a different path:
+       uname -o | grep -q Darwin && SYNCTHING_CONFIG_FILE="$HOME/Library/Application Support/Syncthing/config.xml"
+       apikey_regex="^\s+<apikey>([^<]+)</apikey>$"
+       apikey_line="$(grep -E "$apikey_regex" "$SYNCTHING_CONFIG_FILE")"
 	[[ $apikey_line =~ $apikey_regex ]] &&
 		SYNCTHING_API_KEY=${BASH_REMATCH[1]}
 fi

--- a/syncthing-quick-status.sh
+++ b/syncthing-quick-status.sh
@@ -20,15 +20,12 @@ if [[ -z $SYNCTHING_API_KEY ]]; then
 		SYNCTHING_DEFAULT_CONFIG_FILE="$HOME/Library/Application Support/Syncthing/config.xml"
 	fi
 	: "${SYNCTHING_CONFIG_FILE:="$SYNCTHING_DEFAULT_CONFIG_FILE"}"
-	apikey_regex='^\s+<apikey>([^<]+)</apikey>$'
+	apikey_regex='<apikey>([^<]+)</apikey>'
 	apikey_line="$(grep -E "$apikey_regex" "$SYNCTHING_CONFIG_FILE")"
 	[[ $apikey_line =~ $apikey_regex ]] &&
 		SYNCTHING_API_KEY=${BASH_REMATCH[1]}
 fi
 
-if [[ -z $SYNCTHING_API_KEY ]]; then
-         SYNCTHING_API_KEY=$(echo "$apikey_line" | cut -d ">" -f2|cut -d"<" -f1 2>/dev/null)
-fi
 if [[ -z $SYNCTHING_API_KEY ]]; then
 	echo "No API key in env. Set one of the variables SYNCTHING_API_KEY or SYNCTHING_CONFIG_FILE and try again..."
 	exit 1


### PR DESCRIPTION
@serl 

My PR will introduce a **new GitHub Action for this repo**. On every push in any branch and for every PR [`shellcheck`](https://github.com/koalaman/shellcheck/) will be run for your really nice script.

---

If you want the full advantage, you should change some settings for your repo:
![image](https://user-images.githubusercontent.com/18568381/153452810-f2ed7577-3506-4efd-8d5d-626ee952e6fa.png)

---

This PR makes it also **compatible with Bash-5 and for MacOS**, too.

- Bash-5 needs a different regular expression check
  that is also compatible with Bash-4.
- MacOS stores config.xml in a different path.
- Updated README to reflect these changes/improvements.