### PR TITLE
🩹 fix deprecation warning: Node.js 12 actions are deprecated.

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,6 +11,6 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master


### PR DESCRIPTION
For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
> Please update the following actions to use Node.js 16: actions/checkout@master
Using version v3, latest or master: actions/checkout#689